### PR TITLE
Fixed wrong function name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const inst = await new MyClass(42); // notice the await
 
 await inst.increment();
 
-await inst.foo();  // 43
+await inst.getValue();  // 43
 ```
 
 ## License


### PR DESCRIPTION
Changed the function name `foo` to `getvalue`.

Fixes this [issue](https://github.com/GoogleChromeLabs/comlink-loader/issues/3) 