### PR TITLE
Fix: sanitise options before passing to worker-loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,17 +17,26 @@
 import path from 'path';
 import loaderUtils from 'loader-utils';
 
+const comlinkLoaderSpecificOptions = ['multiple', 'multi', 'singleton'];
+
 export default function loader () { }
 
 loader.pitch = function (request) {
   const options = loaderUtils.getOptions(this) || {};
   const multi = options.multiple || options.multi || options.singleton === false;
+  const workerLoaderOptions = { ...options };
+
+  comlinkLoaderSpecificOptions.forEach(key => {
+    if (workerLoaderOptions[key]) {
+      delete workerLoaderOptions[key];
+    }
+  });
 
   return `
     import {Comlink} from 'comlinkjs';
     ${multi ? '' : 'var inst;'}
     export default function f() {
-      ${multi ? 'var inst =' : 'inst = inst ||'} Comlink.proxy(require('!worker-loader?${JSON.stringify(options)}!${path.resolve(__dirname, 'comlink-worker-loader.js')}!${request}')());
+      ${multi ? 'var inst =' : 'inst = inst ||'} Comlink.proxy(require('!worker-loader?${JSON.stringify(workerLoaderOptions)}!${path.resolve(__dirname, 'comlink-worker-loader.js')}!${request}')());
       return this instanceof f ? new inst : inst;
     }
   `.replace(/\n\s*/g, '');


### PR DESCRIPTION
I am using multi to be able to instantiate multiple workers. Here is how I am using `comlink-loader` in my code.
```
const Worker = await import(
        /* webpackChunkName: "workerized-decode-qr" */ 'comlink-loader?multi&inline!../utils/WorkerisedCode'
      ).then(m => m.default);
```

Upon building, I got this error.
```
ValidationError: Worker Loader Invalid Options

options['multi'] is an invalid additional property
```

Apparently, `comlink-loader` is forwarding all options it receives to `worker-loader`. This PR adds a sanitation step before passing options to `worker-loader`

Build is successful on my machine. Not sure what is causing the CI to fail.

```
➜  comlink-loader git:(master) npm run build

> comlink-loader@1.1.0 build /Users/jacky/Personal/Projects/comlink-loader
> microbundle --inline none --format cjs --no-compress src/*.js

Build output to dist:
        186 B: comlink-worker-loader.js
        554 B: comlink-loader.js
```

