### PR TITLE
Fix function type error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now, let's write a simple module that we're going to load in a Worker:
 **greetings.worker.ts**:
 
 ```ts
-export async function greet(subject: string): string {
+export async function greet(subject: string): Promise<string> {
   return `Hello, ${subject}!`;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ We can import our the above module, and since the filename includes `.worker.ts`
 **index.ts**:
 
 ```ts
-import { greet } from './greetings.worker.ts';
+import { greet } from './greetings.worker';
 
 async function demo() {
   console.log(await greet('dog'));


### PR DESCRIPTION
Fix type error of `greet` function in README.
See also #1.

Also, TypeScript does not allow the addition of `".ts"` when importing `*.ts`.
https://www.typescriptlang.org/docs/handbook/modules.html#import
I also fix the README small mistake about this behavior.