### PR TITLE
Added a `worker` property to access the underlying worker

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,11 +18,19 @@ import sinon from 'sinon';
 import 'jasmine-sinon';
 import MyWorker from 'comlink-loader!./worker';
 
-const OriginalWorker = self.Worker;
-self.Worker = sinon.spy((url, opts) => new OriginalWorker(url, opts));
-
 describe('worker', () => {
+  let OriginalWorker;
   let worker, inst;
+
+  beforeAll(() => {
+    OriginalWorker = self.Worker;
+    self.Worker = sinon.spy((url, opts) => new OriginalWorker(url, opts));
+  });
+
+  afterAll(() => {
+    // Reset the original Worker constructor for next tests
+    self.Worker = OriginalWorker;
+  });
 
   it('should be a factory', async () => {
     worker = new MyWorker();
@@ -74,4 +82,12 @@ describe('worker', () => {
 
     expect(self.Worker).not.toHaveBeenCalled();
   });
+
+  it('should have a property to access the underlying worker', async () => {
+    self.Worker.resetHistory();
+
+    const worker = MyWorker();
+    expect(worker.worker instanceof OriginalWorker).toBe(true);
+  });
 });
+

--- a/test/singleton.test.js
+++ b/test/singleton.test.js
@@ -17,11 +17,19 @@
 import sinon from 'sinon';
 import 'jasmine-sinon';
 
-const OriginalWorker = self.Worker;
-self.Worker = sinon.spy((url, opts) => new OriginalWorker(url, opts));
-
 describe('singleton', () => {
+  let OriginalWorker;
   let exported;
+
+  beforeAll(() => {
+    OriginalWorker = self.Worker;
+    self.Worker = sinon.spy((url, opts) => new OriginalWorker(url, opts));
+  });
+
+  afterAll(() => {
+    // Reset the original Worker constructor for next tests
+    self.Worker = OriginalWorker;
+  });
 
   it('should immediately instantiate the worker', async () => {
     // we're using dynamic import here so the Worker spy can be installed before-hand
@@ -50,4 +58,9 @@ describe('singleton', () => {
       expect(e).toMatch(/Error/);
     }
   });
+
+  it('should have a property to access the underlying worker', async () => {
+    expect(exported.worker instanceof OriginalWorker).toBe(true);
+  });
 });
+


### PR DESCRIPTION
As discussed in https://github.com/GoogleChromeLabs/comlink/pull/487, this is a proposal to implement a worker property to the wrapper returned by this loader. This allows the user to properly terminate the Worker.

I also fixed the setup and tear down code in tests as the spy put in place of the original worker was kept by from one test suite to another and made further tests fail.
