### PR TITLE
Ensuring TypeScript types are correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now, let's write a simple module that we're going to load in a Worker:
 **greetings.worker.ts**:
 
 ```ts
-export async function greet(subject: string): string {
+export async function greet(subject: string): Promise<string> {
   return `Hello, ${subject}!`;
 }
 ```


### PR DESCRIPTION
`async` functions can't return primitives, anything that gets returned must be wrapped in a promise.